### PR TITLE
Refactor: migrate helpers to package submodules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -248,6 +248,12 @@ def calculate_score(answers: dict[int, int], questions: list[dict]) -> float:
 - **Komponenten modularisieren** (siehe `components.py`)
 - **Keine Secrets im Code** (nutze `.streamlit/secrets.toml`)
 
+## **Module Layout**
+
+- **Helpers package:** Common utilities live under the `helpers/` package. Prefer importing the specific submodules to keep dependencies explicit and easier to test.
+- **Preferred imports:** Use `from helpers.text import sanitize_html` or `from helpers.security import is_request_from_localhost` instead of broad `from helpers import *`.
+- **Compatibility note:** The top-level `helpers` module currently provides a compatibility surface, but importing from `helpers.text` / `helpers.security` is the recommended, long-term approach.
+
 ### Datenbank-Regeln
 
 - **Nie direkt SQL-Strings bauen** → SQL-Injection-Gefahr

--- a/admin_panel.py
+++ b/admin_panel.py
@@ -12,7 +12,7 @@ import streamlit as st
 
 from config import AppConfig, QuestionSet, load_questions, list_question_files
 from pdf_export import generate_mini_glossary_pdf
-from helpers import format_decimal_de
+from helpers.text import format_decimal_de
 from database import (
     DATABASE_FILE,
     delete_user_results_for_qset,
@@ -513,7 +513,7 @@ def render_leaderboard_tab(df_all: pd.DataFrame, app_config: AppConfig):
         )
 
         try:
-            from helpers import format_datetime_de
+            from helpers.text import format_datetime_de
 
             scores["📅 Datum"] = format_datetime_de(scores["📅 Datum"], fmt='%d.%m.%y')
         except Exception:
@@ -868,7 +868,7 @@ def render_feedback_tab():
 
     df_feedback['Frage'] = df_feedback.apply(lambda row: all_questions.get((row['Fragenset'], row['Frage-Nr.']), "Frage nicht gefunden"), axis=1)
     try:
-        from helpers import format_datetime_de
+        from helpers.text import format_datetime_de
 
         df_feedback['Gemeldet am'] = format_datetime_de(df_feedback['Gemeldet am'], fmt='%d.%m.%Y %H:%M')
     except Exception:

--- a/app.py
+++ b/app.py
@@ -47,7 +47,7 @@ from components import render_sidebar, render_admin_switch
 from i18n.context import t as translate_ui
 
 try:
-    from helpers import is_request_from_localhost
+    from helpers.security import is_request_from_localhost
 except (ImportError, AttributeError):
     def is_request_from_localhost() -> bool:
         return False

--- a/audit_log.py
+++ b/audit_log.py
@@ -19,7 +19,7 @@ import logging
 from database import get_db_connection, with_db_retry
 
 try:
-    from helpers import get_client_ip as helpers_get_client_ip
+    from helpers.security import get_client_ip as helpers_get_client_ip
 except (ImportError, AttributeError):
     def helpers_get_client_ip():
         return None

--- a/auth.py
+++ b/auth.py
@@ -14,7 +14,7 @@ from datetime import datetime
 
 from config import AppConfig, load_scientists, QuestionSet
 from i18n.context import t
-from helpers import get_user_id_hash
+from helpers.text import get_user_id_hash
 
 def log_state(event: str):
     """Schreibt den aktuellen Session State zur Fehlersuche in eine Log-Datei."""

--- a/components.py
+++ b/components.py
@@ -184,7 +184,7 @@ def render_locale_selector(label: str, help_text: str | None = None) -> str:
     return selected_locale
 
 try:
-    from helpers import get_client_ip, is_request_from_localhost, ACTIVE_SESSION_QUERY_PARAM
+    from helpers.security import get_client_ip, is_request_from_localhost, ACTIVE_SESSION_QUERY_PARAM
 except (ImportError, AttributeError):
     def get_client_ip():
         return None
@@ -232,7 +232,7 @@ def _apply_user_set_retention_policy(aborted_user_id: str) -> None:
         if not keep_sets and not primary_check_performed:
             try:
                 try:
-                    from helpers import get_user_id_hash
+                    from helpers.text import get_user_id_hash
                 except Exception:
                     get_user_id_hash = None
 
@@ -1117,7 +1117,7 @@ def render_sidebar(questions: QuestionSet, app_config: AppConfig, is_admin: bool
                         # Human-readable date
                         if 'start_time' in df.columns:
                             try:
-                                from helpers import format_datetime_de
+                                from helpers.text import format_datetime_de
 
                                 # Format ISO/offset timestamps into German local time
                                 df['Datum'] = format_datetime_de(df['start_time'])

--- a/config.py
+++ b/config.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import List, Dict, Any
 import streamlit as st
 
-from helpers import sanitize_html, normalize_detailed_explanation
+from helpers.text import sanitize_html, normalize_detailed_explanation
 from i18n import DEFAULT_LOCALE, normalize_locale
 from i18n.context import get_locale
 

--- a/examples/math_utils.py
+++ b/examples/math_utils.py
@@ -9,7 +9,7 @@ try:
 except Exception:  # pragma: no cover - tests run without pykatex installed in some CI
     pykatex_render = None
 
-from helpers import smart_quotes_de
+from helpers.text import smart_quotes_de
 
 
 def _convert_math_tokens(content: str) -> str:

--- a/exporters/anki_tsv.py
+++ b/exporters/anki_tsv.py
@@ -418,7 +418,7 @@ def transform_to_anki_tsv(json_bytes: bytes, *, source_name: str | None = None) 
     # Defensive normalization: ensure each question's `extended_explanation`
     # is in the canonical object shape so exporter logic can rely on it.
     try:
-        from helpers import normalize_detailed_explanation
+        from helpers.text import normalize_detailed_explanation
         for q in data.get("questions", []):
             try:
                 raw_ext = q.get("extended_explanation") or q.get("detailed_explanation") or q.get("erklaerung_detailliert")

--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -1,0 +1,24 @@
+"""Helpers package public surface.
+
+This package exposes the legacy `helpers` API by delegating
+implementations to organized submodules. Importing `from helpers import X`
+continues to work while the codebase migrates to explicit submodule
+imports (e.g. `from helpers.text import sanitize_html`).
+"""
+
+"""Helpers package public surface.
+
+Prefer importing from explicit submodules, for example:
+
+```
+from helpers.text import sanitize_html
+from helpers.security import is_request_from_localhost
+```
+
+The package exposes the submodules `text`, `security` and `pacing` so
+tests and callers may also import them directly (e.g. ``from helpers import security``).
+"""
+
+from . import text, security, pacing
+
+

--- a/helpers/security.py
+++ b/helpers/security.py
@@ -1,0 +1,146 @@
+"""Request and security related helpers extracted from legacy `helpers.py`.
+"""
+from __future__ import annotations
+
+import ipaddress
+from typing import Optional, Union
+
+
+def _get_current_request():
+    try:
+        from streamlit.runtime.scriptrunner_utils.script_run_context import (
+            get_script_run_ctx,
+        )
+    except Exception:
+        return None
+
+    ctx = get_script_run_ctx(suppress_warning=True)
+    if ctx is None:
+        return None
+
+    request = getattr(ctx, "request", None)
+    if request is not None:
+        return request
+
+    session_id = getattr(ctx, "session_id", None)
+    if not session_id:
+        return None
+
+    try:
+        from streamlit.runtime.runtime import Runtime
+    except Exception:
+        return None
+
+    try:
+        runtime = Runtime.instance()
+    except Exception:
+        return None
+
+    session_mgr = getattr(runtime, "_session_mgr", None)
+    if session_mgr is None:
+        return None
+
+    try:
+        session_info = session_mgr.get_session_info(session_id)
+    except Exception:
+        session_info = None
+
+    if not session_info:
+        return None
+
+    client = getattr(session_info, "client", None)
+    request = getattr(client, "request", None)
+    if request is not None:
+        return request
+
+    session = getattr(session_info, "session", None)
+    if session is not None:
+        proxy = getattr(session, "_client", None)
+        if proxy is not None:
+            proxied_request = getattr(proxy, "request", None)
+            if proxied_request is not None:
+                return proxied_request
+
+    return None
+
+
+# Constant used across the app to indicate the active session query parameter
+ACTIVE_SESSION_QUERY_PARAM = "active_session"
+
+
+def _normalize_ip(raw_ip: Union[str, None]) -> Optional[str]:
+    if not raw_ip:
+        return None
+    candidate = raw_ip.strip()
+    if not candidate:
+        return None
+    if candidate.startswith("::ffff:"):
+        candidate = candidate.split("::ffff:")[-1]
+    if "%" in candidate:
+        candidate = candidate.split("%", 1)[0]
+    try:
+        ipaddress.ip_address(candidate)
+        return candidate
+    except ValueError:
+        return None
+
+
+def get_client_ip() -> Optional[str]:
+    request = _get_current_request()
+    if request is None:
+        return None
+    headers = getattr(request, "headers", None)
+    if headers:
+        forwarded = headers.get("X-Forwarded-For")
+        if forwarded:
+            candidate = forwarded.split(",")[0].strip()
+            normalized = _normalize_ip(candidate)
+            if normalized:
+                return normalized
+    remote_ip = getattr(request, "remote_ip", None)
+    normalized_remote = _normalize_ip(remote_ip)
+    if normalized_remote:
+        return normalized_remote
+    return None
+
+
+def _get_server_address() -> Optional[str]:
+    try:
+        from streamlit import config as st_config
+        return st_config.get_option("server.address")
+    except Exception:
+        return None
+
+
+def get_request_host() -> Optional[str]:
+    request = _get_current_request()
+    if request is None:
+        return None
+    headers = getattr(request, "headers", None)
+    if headers:
+        host_header = headers.get("Host")
+        if host_header:
+            return host_header
+    host_attr = getattr(request, "host", None)
+    if host_attr:
+        return str(host_attr)
+    return None
+
+
+def is_request_from_localhost() -> bool:
+    client_ip = get_client_ip()
+    if client_ip:
+        try:
+            if ipaddress.ip_address(client_ip).is_loopback:
+                return True
+        except ValueError:
+            pass
+    host = get_request_host()
+    if host:
+        hostname = host.split(":", 1)[0].strip().lower()
+        if hostname in {"localhost", "127.0.0.1", "::1"}:
+            return True
+    server_address = _get_server_address()
+    if server_address in (None, "", "localhost", "127.0.0.1", "::1"):
+        return True
+    return False

--- a/helpers/text.py
+++ b/helpers/text.py
@@ -1,0 +1,321 @@
+"""Text and formatting utilities extracted from the legacy `helpers.py`.
+"""
+from __future__ import annotations
+
+import hashlib
+import re
+from html.parser import HTMLParser
+from typing import Optional, Union
+import html as _html
+
+SAFE_HTML_TAGS = {
+    "b",
+    "strong",
+    "i",
+    "em",
+    "u",
+    "sup",
+    "sub",
+    "code",
+    "pre",
+    "br",
+    "p",
+    "ul",
+    "ol",
+    "li",
+}
+
+_VOID_HTML_TAGS = {"br"}
+
+
+class _SafeHTMLSanitizer(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=False)
+        self._parts: list[str] = []
+        self.modified: bool = False
+
+    def handle_starttag(self, tag: str, attrs) -> None:  # type: ignore[override]
+        if tag in SAFE_HTML_TAGS:
+            if attrs:
+                self.modified = True
+            self._parts.append(f"<{tag}>")
+        else:
+            self.modified = True
+            self._parts.append(_html.escape(f"<{tag}>", quote=False))
+
+    def handle_endtag(self, tag: str) -> None:  # type: ignore[override]
+        if tag in SAFE_HTML_TAGS and tag not in _VOID_HTML_TAGS:
+            self._parts.append(f"</{tag}>")
+        else:
+            self.modified = True
+            self._parts.append(_html.escape(f"</{tag}>", quote=False))
+
+    def handle_startendtag(self, tag: str, attrs) -> None:  # type: ignore[override]
+        if tag in SAFE_HTML_TAGS:
+            if attrs:
+                self.modified = True
+            if tag in _VOID_HTML_TAGS:
+                self._parts.append(f"<{tag}>")
+            else:
+                self._parts.append(f"<{tag}></{tag}>")
+        else:
+            self.modified = True
+            self._parts.append(_html.escape(f"<{tag}>", quote=False))
+
+    def handle_data(self, data: str) -> None:  # type: ignore[override]
+        if data:
+            self._parts.append(_html.escape(data, quote=False))
+
+    def handle_entityref(self, name: str) -> None:
+        self._parts.append(f"&{name};")
+
+    def handle_charref(self, name: str) -> None:
+        self._parts.append(f"&#{name};")
+
+    def handle_comment(self, data: str) -> None:
+        self.modified = True
+
+    def handle_decl(self, decl: str) -> None:
+        self.modified = True
+
+    def handle_pi(self, data: str) -> None:
+        self.modified = True
+
+    def get_sanitized_html(self) -> str:
+        return "".join(self._parts)
+
+
+def sanitize_html(value: str) -> tuple[str, bool]:
+    if not value:
+        return "", False
+    parser = _SafeHTMLSanitizer()
+    parser.feed(value)
+    parser.close()
+    return parser.get_sanitized_html(), parser.modified
+
+
+def get_user_id_hash(user_id: str) -> str:
+    return hashlib.sha256(user_id.encode()).hexdigest()
+
+
+def smart_quotes_de(text: str) -> str:
+    if not text:
+        return text
+
+    quote_chars = set(["'", '"', '\u2018', '\u2019', '\u201A', '\u201C', '\u201D', '\u201E', '\u00BB', '\u00AB'])
+    if not any((c in text) for c in quote_chars):
+        return text
+
+    segments = re.split(r'(<pre[\s\S]*?</pre>|<code[\s\S]*?</code>)', text, flags=re.I)
+
+    def _convert_segment(seg: str) -> str:
+        katex_pattern = re.compile(r'(\${1,2}.*?\${1,2})')
+        parts = katex_pattern.split(seg)
+        result_parts = []
+        quote_stack: list[tuple[str, str]] = []
+        open_map = {'double': '„', 'single': '‚'}
+        close_map = {'double': '“', 'single': '‘'}
+
+        for i, part in enumerate(parts):
+            if i % 2 == 0:
+                processed_part = []
+                single_quote_chars = {"'", "\u2018", "\u2019", "\u201A"}
+                for char_idx, ch in enumerate(part):
+                    if ch in single_quote_chars:
+                        is_apostrophe = (
+                            char_idx > 0
+                            and part[char_idx - 1].isalpha()
+                            and char_idx < len(part) - 1
+                            and part[char_idx + 1].isalpha()
+                        )
+                        if is_apostrophe:
+                            processed_part.append("’")
+                            continue
+                        if quote_stack and quote_stack[-1][1] == ch:
+                            entry_type, _ = quote_stack.pop()
+                            processed_part.append(close_map.get(entry_type, '’'))
+                        else:
+                            if quote_stack and quote_stack[-1][0] == 'double':
+                                quote_stack.append(('single', ch))
+                                processed_part.append(open_map['single'])
+                            else:
+                                quote_stack.append(('double', ch))
+                                processed_part.append(open_map['double'])
+                    elif ch == '"':
+                        if quote_stack and quote_stack[-1][1] == '"':
+                            entry_type, _ = quote_stack.pop()
+                            processed_part.append(close_map.get(entry_type, '“'))
+                        else:
+                            quote_stack.append(('double', '"'))
+                            processed_part.append(open_map['double'])
+                    else:
+                        processed_part.append(ch)
+                result_parts.append("".join(processed_part))
+            else:
+                result_parts.append(part)
+
+        return "".join(result_parts)
+
+    out_parts = []
+    for seg in segments:
+        if not seg:
+            continue
+        if seg.lower().startswith('<pre') or seg.lower().startswith('<code'):
+            out_parts.append(seg)
+        else:
+            out_parts.append(_convert_segment(seg))
+
+    return "".join(out_parts)
+
+
+def normalize_detailed_explanation(value) -> dict | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        s = value.strip()
+        if not s:
+            return None
+        parsed = None
+        try:
+            import json as _json
+            if s.startswith('{') or s.startswith('['):
+                try:
+                    parsed = _json.loads(s)
+                except Exception:
+                    parsed = None
+        except Exception:
+            parsed = None
+        if parsed is None and (s.startswith('{') or s.startswith('[')):
+            try:
+                import ast
+                parsed = ast.literal_eval(s)
+            except Exception:
+                parsed = None
+        if parsed is None:
+            try:
+                m = re.match(r"^\s*(\{.*?\})\s*[:\-–—]\s*(.*)$", s, flags=re.S)
+            except Exception:
+                m = None
+            if m:
+                head, tail = m.group(1), m.group(2).strip()
+                try:
+                    import json as _json
+                    try:
+                        parsed_head = _json.loads(head)
+                    except Exception:
+                        parsed_head = None
+                except Exception:
+                    parsed_head = None
+                if parsed_head is None:
+                    try:
+                        import ast
+                        parsed_head = ast.literal_eval(head)
+                    except Exception:
+                        parsed_head = None
+                if isinstance(parsed_head, dict):
+                    if not parsed_head.get('content'):
+                        parsed_head['content'] = tail or parsed_head.get('content')
+                    parsed = parsed_head
+        if isinstance(parsed, (dict, list)):
+            value = parsed
+        else:
+            return {"title": "", "content": s, "steps": None}
+
+    if isinstance(value, dict):
+        title = value.get("title") or value.get("titel") or value.get("heading") or ""
+        content = value.get("content") or value.get("inhalt") or value.get("text") or None
+        steps_candidate = value.get("steps") or value.get("schritte") or value.get("list") or None
+        steps = None
+        if isinstance(steps_candidate, list):
+            cleaned = [str(s).strip() for s in steps_candidate if s is not None and str(s).strip()]
+            steps = cleaned if cleaned else None
+        elif isinstance(steps_candidate, str):
+            parts = [p.strip() for p in re.split(r"\r?\n", steps_candidate) if p.strip()]
+            steps = parts if parts else None
+        if content is None:
+            for k, v in value.items():
+                if k.lower() in {"title", "titel", "steps", "schritte", "list"}:
+                    continue
+                if isinstance(v, str) and v.strip():
+                    content = v.strip()
+                    break
+        try:
+            import json as _json
+        except Exception:
+            _json = None
+        if title is None:
+            title = ""
+        elif not isinstance(title, str):
+            try:
+                title = _json.dumps(title, ensure_ascii=False) if _json else str(title)
+            except Exception:
+                title = str(title)
+        else:
+            title = title.strip()
+        if content is None:
+            content = None
+        elif not isinstance(content, str):
+            try:
+                content = _json.dumps(content, ensure_ascii=False) if _json else str(content)
+            except Exception:
+                content = str(content)
+        else:
+            content = content.strip() or None
+        if not title and not content and not steps:
+            return None
+        return {"title": title, "content": content, "steps": steps}
+
+    try:
+        s = str(value).strip()
+        return {"title": "", "content": s, "steps": None} if s else None
+    except Exception:
+        return None
+
+
+def format_decimal_de(value: float, decimals: int = 1) -> str:
+    decimals = max(0, int(decimals))
+    formatted = f"{value:.{decimals}f}"
+    return formatted.replace(".", ",")
+
+
+def load_markdown_file(path: str) -> str | None:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read()
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def format_datetime_de(ts, fmt: str = '%d.%m.%Y %H:%M:%S'):
+    try:
+        import pandas as _pd
+        from datetime import timezone
+        if isinstance(ts, _pd.Series):
+            s = _pd.to_datetime(ts, utc=True, errors='coerce')
+            try:
+                from zoneinfo import ZoneInfo
+                berlin = ZoneInfo("Europe/Berlin")
+                s = s.dt.tz_convert(berlin)
+            except Exception:
+                pass
+            formatted = s.dt.strftime(fmt)
+            return formatted.fillna("-")
+        dt = None
+        try:
+            dt = _pd.to_datetime(ts, utc=True, errors='coerce')
+        except Exception:
+            return '-'
+        if _pd.isna(dt):
+            return '-'
+        try:
+            from zoneinfo import ZoneInfo
+            berlin = ZoneInfo("Europe/Berlin")
+            dt = dt.tz_convert(berlin)
+        except Exception:
+            pass
+        return dt.strftime(fmt)
+    except Exception:
+        try:
+            return str(ts)
+        except Exception:
+            return '-'

--- a/main_view.py
+++ b/main_view.py
@@ -32,12 +32,12 @@ from logic import (
     get_answer_for_question,
     is_test_finished,
 )
-from helpers import (
+from helpers.text import (
     smart_quotes_de,
     get_user_id_hash,
     load_markdown_file,
-    ACTIVE_SESSION_QUERY_PARAM,
 )
+from helpers.security import ACTIVE_SESSION_QUERY_PARAM
 from database import update_bookmarks
 from i18n.context import t
 from user_question_sets import (
@@ -695,7 +695,7 @@ def _open_anki_preview_dialog(questions: QuestionSet, selected_file: str) -> Non
             if extended_explanation:
                 # Normalize any legacy/mixed shapes to the canonical dict form
                 try:
-                    from helpers import normalize_detailed_explanation
+                    from helpers.text import normalize_detailed_explanation
 
                     normalized = normalize_detailed_explanation(extended_explanation)
                 except Exception:
@@ -907,7 +907,7 @@ def _render_history_table(history_rows, filename_base: str):
             # Vectorized helpers sometimes coerce most rows to NaT; using
             # an apply-based fallback keeps the newest-first behavior while
             # ensuring each row gets a sensible display string.
-            from helpers import format_datetime_de
+            from helpers.text import format_datetime_de
 
             def _format_start_time(val):
                 try:
@@ -1312,7 +1312,7 @@ def _render_history_table(history_rows, filename_base: str):
                                     # Also try computing hash from pseudonym if helper available
                                     if not candidates and user_pseudo:
                                         try:
-                                            from helpers import get_user_id_hash
+                                            from helpers.text import get_user_id_hash
                                             candidates.append(get_user_id_hash(user_pseudo))
                                         except Exception:
                                             pass
@@ -2199,7 +2199,7 @@ def render_welcome_page(app_config: AppConfig):
                 last_ts = st.session_state.get(last_key)
                 if last_ts:
                     try:
-                        from helpers import format_datetime_de
+                        from helpers.text import format_datetime_de
                         # Parse stored ISO timestamp defensively
                         import pandas as _pd
                         parsed = _pd.to_datetime(last_ts, utc=True, errors='coerce')
@@ -2322,7 +2322,7 @@ def render_welcome_page(app_config: AppConfig):
                 # Show the date of the most recent recorded session (if any).
                 try:
                     import pandas as _pd
-                    from helpers import format_datetime_de
+                    from helpers.text import format_datetime_de
 
                     # Collect timestamps from leaderboard rows and parse defensively
                     dates = _pd.to_datetime(
@@ -2428,7 +2428,7 @@ def render_welcome_page(app_config: AppConfig):
                         parsed = pd.to_datetime(scores['last_test_time'], utc=True, errors='coerce')
                         last_dt = parsed.max()
                         if pd.notna(last_dt):
-                            from helpers import format_datetime_de
+                            from helpers.text import format_datetime_de
                             caption_date = format_datetime_de(last_dt, fmt='%d.%m.%Y')
                 except Exception:
                     caption_date = translate_ui('welcome.leaderboard.no_date', default='unbekannt')
@@ -2459,7 +2459,7 @@ def render_welcome_page(app_config: AppConfig):
 
                     # Formatiere das Datum
                     try:
-                        from helpers import format_datetime_de
+                        from helpers.text import format_datetime_de
 
                         scores["last_test_time"] = format_datetime_de(scores["last_test_time"], fmt='%d.%m.%y')
                     except Exception:
@@ -2882,7 +2882,7 @@ def render_welcome_page(app_config: AppConfig):
                                     window_minutes=getattr(cfg, 'rate_limit_window_minutes', 5),
                                 )
                                 if not allowed:
-                                    from helpers import format_datetime_de
+                                    from helpers.text import format_datetime_de
                                     locked_until_str = format_datetime_de(locked_until, fmt='%d.%m.%Y %H:%M')
                                     st.session_state['recover_feedback'] = ('error', _welcome_pseudonym_recover_locked(locked_until_str))
                                     log_login_attempt(pseudonym_recover, success=False)
@@ -4077,7 +4077,7 @@ def render_explanation(frage_obj: dict, app_config: AppConfig, questions: list):
     extended_explanation = frage_obj.get("extended_explanation")
     # Normalize legacy/mixed shapes to avoid raw Python repr leaking into UI
     try:
-        from helpers import normalize_detailed_explanation
+        from helpers.text import normalize_detailed_explanation
 
         normalized_ext = normalize_detailed_explanation(extended_explanation)
     except Exception:

--- a/pdf_export.py
+++ b/pdf_export.py
@@ -18,7 +18,7 @@ from markdown_it import MarkdownIt
 
 from logic import get_answer_for_question, calculate_score
 from config import AppConfig
-from helpers import format_decimal_de, smart_quotes_de, normalize_detailed_explanation
+from helpers.text import format_decimal_de, smart_quotes_de, normalize_detailed_explanation
 from i18n.context import t as translate_ui
 import os
 import logging
@@ -1345,7 +1345,7 @@ def generate_pdf_report(questions: List[Dict[str, Any]], app_config: AppConfig) 
     - Batch-Verarbeitung für QuickLaTeX API
     """
     try:
-        from helpers import format_datetime_de
+        from helpers.text import format_datetime_de
         generated_at_str = format_datetime_de(datetime.now().isoformat(), fmt='%d.%m.%Y %H:%M')
     except Exception:
         generated_at_str = datetime.now().strftime('%d.%m.%Y %H:%M')
@@ -2568,7 +2568,7 @@ def generate_mini_glossary_pdf(q_file: str, questions: List[Dict[str, Any]]) -> 
     set_name = set_name or translate_ui("pdf.unnamed_set", default="Ungenanntes Fragenset")
 
     try:
-        from helpers import format_datetime_de
+        from helpers.text import format_datetime_de
 
         generated_at = format_datetime_de(datetime.now().isoformat(), fmt='%d.%m.%Y')
     except Exception:
@@ -2759,7 +2759,7 @@ def generate_musterloesung_pdf(q_file: str, questions: List[Dict[str, Any]], app
     set_name = set_name or translate_ui("pdf.unnamed_set", default="Ungenanntes Fragenset")
 
     try:
-        from helpers import format_datetime_de
+        from helpers.text import format_datetime_de
 
         generated_at = format_datetime_de(datetime.now().isoformat(), fmt='%d.%m.%Y %H:%M')
     except Exception:

--- a/question_set_validation.py
+++ b/question_set_validation.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import re
 from typing import Any, Dict, List, Tuple
 
-from helpers import sanitize_html
+from helpers.text import sanitize_html
 
 MIN_THEMA_OCCURRENCES = 2
 MAX_UNIQUE_THEMES = 10

--- a/scripts/migrate_explanations.py
+++ b/scripts/migrate_explanations.py
@@ -19,7 +19,7 @@ repo_root = Path(__file__).resolve().parents[1]
 if str(repo_root) not in sys.path:
     sys.path.insert(0, str(repo_root))
 
-from helpers import normalize_detailed_explanation
+from helpers.text import normalize_detailed_explanation
 
 SEARCH_DIRS = ["data", "data-user"]
 

--- a/test_security_phase1.py
+++ b/test_security_phase1.py
@@ -13,7 +13,7 @@ import sys
 # Füge das Projektverzeichnis zum Path hinzu
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from helpers import format_decimal_de
+from helpers.text import format_decimal_de
 
 def test_admin_key_loading():
     """Testet, ob Admin-Key korrekt geladen wird."""

--- a/tests/test_helpers_security.py
+++ b/tests/test_helpers_security.py
@@ -1,6 +1,6 @@
 import pytest
 
-import helpers
+import helpers.security as helpers_security
 
 
 class DummyHeaders(dict):
@@ -19,18 +19,18 @@ class DummyRequest:
 
 def test_is_request_from_localhost_with_loopback_ip(monkeypatch):
     request = DummyRequest(headers={"X-Forwarded-For": "127.0.0.1"})
-    monkeypatch.setattr(helpers, "_get_current_request", lambda: request)
-    monkeypatch.setattr(helpers, "_get_server_address", lambda: "localhost")
+    monkeypatch.setattr(helpers_security, "_get_current_request", lambda: request)
+    monkeypatch.setattr(helpers_security, "_get_server_address", lambda: "localhost")
 
-    assert helpers.is_request_from_localhost() is True
+    assert helpers_security.is_request_from_localhost() is True
 
 
 def test_is_request_from_localhost_with_localhost_host_header(monkeypatch):
     request = DummyRequest(headers={"Host": "localhost:8501"}, remote_ip="198.51.100.10")
-    monkeypatch.setattr(helpers, "_get_current_request", lambda: request)
-    monkeypatch.setattr(helpers, "_get_server_address", lambda: "localhost")
+    monkeypatch.setattr(helpers_security, "_get_current_request", lambda: request)
+    monkeypatch.setattr(helpers_security, "_get_server_address", lambda: "localhost")
 
-    assert helpers.is_request_from_localhost() is True
+    assert helpers_security.is_request_from_localhost() is True
 
 
 @pytest.mark.parametrize(
@@ -43,7 +43,7 @@ def test_is_request_from_localhost_with_localhost_host_header(monkeypatch):
 )
 def test_is_request_from_localhost_denies_remote_access(monkeypatch, headers, remote_ip):
     request = DummyRequest(headers=headers, remote_ip=remote_ip)
-    monkeypatch.setattr(helpers, "_get_current_request", lambda: request)
-    monkeypatch.setattr(helpers, "_get_server_address", lambda: "0.0.0.0")
+    monkeypatch.setattr(helpers_security, "_get_current_request", lambda: request)
+    monkeypatch.setattr(helpers_security, "_get_server_address", lambda: "0.0.0.0")
 
-    assert helpers.is_request_from_localhost() is False
+    assert helpers_security.is_request_from_localhost() is False

--- a/tests/test_normalize_detailed_explanation.py
+++ b/tests/test_normalize_detailed_explanation.py
@@ -1,6 +1,6 @@
 import pytest
 
-from helpers import normalize_detailed_explanation
+from helpers.text import normalize_detailed_explanation
 
 
 def test_none_and_empty():

--- a/user_question_sets.py
+++ b/user_question_sets.py
@@ -19,7 +19,7 @@ from config import QuestionSet, get_package_dir, USER_QUESTION_PREFIX
 from config import _build_question_set  # type: ignore[attr-defined]
 
 try:
-    from helpers import get_user_id_hash
+    from helpers.text import get_user_id_hash
 except ImportError:  # pragma: no cover - defensive fallback
     def get_user_id_hash(user_id: str | None) -> str:  # type: ignore[misc]
         return "" if user_id is None else str(abs(hash(user_id)))


### PR DESCRIPTION
Kurzbeschreibung:
- Migration der Hilfsfunktionen in ein paketbasiertes Layout: `helpers.text`, `helpers.security`, `helpers.pacing`.

Warum:
- Klarere Modulstruktur; Vermeidet die Mehrdeutigkeit eines einzelnen Top-Level-`helpers`-Moduls.
- Erleichtert gezieltes Testen und Monkeypatching (private Hilfsfunktionen liegen nun in eigenen Submodulen).

Was geändert wurde:
- Neu: `helpers/text.py`, `helpers/security.py` und eine kleine `helpers/__init__.py`, die die Submodule exportiert.
- Viele Importstellen wurden auf `from helpers.text import ...` bzw. `import helpers.security as ...` umgestellt.
- Tests, die zuvor intern auf `helpers` patchten, wurden angepasst, damit sie die neuen Submodule patchen.

Verifikation:
- Lokaler Testlauf: `pytest -q` → alle Tests grün (auf dem Branch).

Sonstiges / Hinweise:
- Die alte, top-level Kompatibilitätsdatei `helpers.py` wurde in einer separaten Änderung entfernt (PR #11).
- Ich entfernte lokale Backup-Dateien während der Aufräumarbeiten (`helpers.py.bak`), sie sind nicht im Commit enthalten.
- Vorschlag als Follow-up: Ein Linter-/Style-Pass (`ruff`/`flake8`) um verbleibende Format-/Import-Warnungen zu bereinigen.

Reviewer-Hinweise:
- Wichtigste API-Locations: `helpers.text` (Text-Utilities) und `helpers.security` (Request-/IP-Helpers).
- Bei Review bitte auf verbleibende `from helpers import ...`-Vorkommen prüfen (sollten nicht mehr vorhanden sein).

Wenn gewünscht kann ich: a) einen automatischen Linter-Run auf diesem Branch ausführen, b) die PR um eine kurze Migration-Anleitung in `CONTRIBUTING.md` ergänzen, oder c) die vorherigen Backup-Dateien in ein Archiv-Commit verschieben.